### PR TITLE
add dependencies to fluorine.js benchmark

### DIFF
--- a/waterfall/fluorine.js
+++ b/waterfall/fluorine.js
@@ -1,3 +1,5 @@
+require('../node_modules/fluorine/node_modules/neon');
+require('../node_modules/fluorine/node_modules/neon/stdlib');
 require('fluorine');
 
 var fs        = require('fs');
@@ -39,7 +41,7 @@ function start(done) {
         console.log("Executed in " + time + " ms");
 
         if (runs++ < 1000) {
-            return start();
+            return flow.runNode(flow.children[0]);
         }
         console.log("All runs completed in " + (totalTime/runs) + ' ms average');
         console.log("Total time: " + totalTime + ' ms');


### PR DESCRIPTION
use same flow because fluorine can rerun on itself
this improves performance because fluorine no longer needs to compute a new graph every time.
